### PR TITLE
tabs->spaces

### DIFF
--- a/background.tex
+++ b/background.tex
@@ -92,9 +92,9 @@ model both \emph{periodic} and \emph{aperiodic} tasks and maps well onto typical
 \begin{listing}
     \begin{ccode}
 for (;;) {
-	// job arrives
-	doJob();
-	// job completes before deadline
+    // job arrives
+    doJob();
+    // job completes before deadline
     // sleep until next job is ready
     sleep();
 }

--- a/phd.tex
+++ b/phd.tex
@@ -304,7 +304,7 @@
 \input{implementation}
 \input{evaluation}
 \input{conclusion}
-
+\TODO{Consistent tab length in code blocks}
 %{
 %\backmatter - back matter screws up numbering for appendixes so don't use it
 \cleardoublepage


### PR DESCRIPTION
I did a grep of all the other tabs but they are only before tables or latex commands so I don't think they have any effect.  Some code blocks use 4 spaces for tabs and others use 2.  I don't know if you want to make them consistent so I added a TODO to track it,